### PR TITLE
Fix build-breaking unused import in Resource.js

### DIFF
--- a/src/components/pages/resource/Resource.js
+++ b/src/components/pages/resource/Resource.js
@@ -3,7 +3,6 @@ import "./Resource.scss";
 import Page from "../../atoms/page/Page";
 import Icon from "../../atoms/icon/Icon";
 import linkedin from "../../../assets/linkedin.png";
-import document from "../../../assets/document.png";
 import github from "../../../assets/github.png";
 
 function Resource() {


### PR DESCRIPTION
# Intent
`CI=true npm run build` was broken on `master` by a pre-existing, unrelated lint error, blocking build verification for the rest of this PR stack.

# Solution
Remove the unused import.

Merge first — the rest of the UI polish stack (#6–#11) is based on this branch.
