### PR TITLE
Add HP/MP stat bars to Profile card

### DIFF
--- a/src/components/atoms/stat-bar/StatBar.js
+++ b/src/components/atoms/stat-bar/StatBar.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+import "./StatBar.scss";
+
+function StatBar({ label, value }) {
+  return (
+    <div className={`stat-bar stat-bar-${label.toLowerCase()}`}>
+      <span className="stat-bar-label">{label}</span>
+      <div className="stat-bar-track">
+        <div className="stat-bar-fill" style={{ width: `${value}%` }} />
+      </div>
+      <span className="stat-bar-value">{value}%</span>
+    </div>
+  );
+}
+
+export default StatBar;

--- a/src/components/atoms/stat-bar/StatBar.js
+++ b/src/components/atoms/stat-bar/StatBar.js
@@ -2,14 +2,14 @@ import React from "react";
 
 import "./StatBar.scss";
 
-function StatBar({ label, value }) {
+function StatBar({ label, value, max }) {
   return (
     <div className={`stat-bar stat-bar-${label.toLowerCase()}`}>
       <span className="stat-bar-label">{label}</span>
       <div className="stat-bar-track">
-        <div className="stat-bar-fill" style={{ width: `${value}%` }} />
+        <div className="stat-bar-fill" style={{ width: `${(value / max) * 100}%` }} />
+        <span className="stat-bar-value">{value}/{max}</span>
       </div>
-      <span className="stat-bar-value">{value}%</span>
     </div>
   );
 }

--- a/src/components/atoms/stat-bar/StatBar.scss
+++ b/src/components/atoms/stat-bar/StatBar.scss
@@ -15,8 +15,9 @@
   }
 
   .stat-bar-track {
+    position: relative;
     flex: 1;
-    height: $spacing-2;
+    height: $spacing-4;
     margin: 0 $spacing-2;
     background-color: $color-grey-1;
     border: 1px solid $color-primary-dark;
@@ -31,9 +32,12 @@
   }
 
   .stat-bar-value {
-    width: 2.25rem;
-    text-align: right;
-    color: $color-primary-grey;
+    position: absolute;
+    top: 50%;
+    right: $spacing-1;
+    transform: translateY(-50%);
+    color: $color-white;
+    text-shadow: 0 0 2px rgba($color-primary-dark, 0.8);
   }
 
   &.stat-bar-hp .stat-bar-fill {

--- a/src/components/atoms/stat-bar/StatBar.scss
+++ b/src/components/atoms/stat-bar/StatBar.scss
@@ -1,0 +1,46 @@
+@import "../../../styles/theme";
+
+.stat-bar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+
+  font-size: $font-xs;
+
+  .stat-bar-label {
+    width: 1.5rem;
+    font-weight: $font-bold;
+    color: $color-primary-dark;
+  }
+
+  .stat-bar-track {
+    flex: 1;
+    height: $spacing-2;
+    margin: 0 $spacing-2;
+    background-color: $color-grey-1;
+    border: 1px solid $color-primary-dark;
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .stat-bar-fill {
+    height: 100%;
+    border-radius: 1px;
+    transition: width $a-short ease-in-out;
+  }
+
+  .stat-bar-value {
+    width: 2.25rem;
+    text-align: right;
+    color: $color-primary-grey;
+  }
+
+  &.stat-bar-hp .stat-bar-fill {
+    background-color: $color-stat-hp;
+  }
+
+  &.stat-bar-mp .stat-bar-fill {
+    background-color: $color-secondary-blue;
+  }
+}

--- a/src/components/atoms/stat-bar/tests/StatBar.test.js
+++ b/src/components/atoms/stat-bar/tests/StatBar.test.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import StatBar from "../StatBar";
+
+describe("StatBar", () => {
+  it("renders the value/max text", () => {
+    render(<StatBar label="HP" value={80} max={100} />);
+    expect(screen.getByText("80/100")).not.toBeNull();
+  });
+
+  it("sets the fill width as a percentage of max", () => {
+    const { container } = render(<StatBar label="MP" value={25} max={50} />);
+    const fill = container.querySelector(".stat-bar-fill");
+    expect(fill.style.width).toBe("50%");
+  });
+
+  it("derives the modifier class from the label", () => {
+    const { container } = render(<StatBar label="HP" value={80} max={100} />);
+    expect(container.querySelector(".stat-bar-hp")).not.toBeNull();
+  });
+});

--- a/src/components/molecules/profile/Profile.js
+++ b/src/components/molecules/profile/Profile.js
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+
+import StatBar from "../../atoms/stat-bar/StatBar";
 import "./Profile.scss";
 
 // Random stat value between 75 and 100 (inclusive-ish), rounded to whole number
@@ -6,22 +8,9 @@ function randomStat() {
   return Math.floor(Math.random() * (100 - 75 + 1)) + 75;
 }
 
-function StatBar({ label, value, className }) {
-  return (
-    <div className={`stat-bar ${className}`}>
-      <span className="stat-bar-label">{label}</span>
-      <div className="stat-bar-track">
-        <div className="stat-bar-fill" style={{ width: `${value}%` }} />
-      </div>
-      <span className="stat-bar-value">{value}%</span>
-    </div>
-  );
-}
-
 function Profile({ profile, label }) {
   // Computed once per mount so the values don't jitter on re-render
-  const [hp] = useState(() => randomStat());
-  const [mp] = useState(() => randomStat());
+  const [{ hp, mp }] = useState(() => ({ hp: randomStat(), mp: randomStat() }));
 
   return (
     <div className="profile-container">
@@ -31,8 +20,8 @@ function Profile({ profile, label }) {
         <div>LVL: Senior Software Engineer</div>
         <div>JOB: Editing Performance @ Canva</div>
         <div className="profile-stats">
-          <StatBar label="HP" value={hp} className="stat-bar-hp" />
-          <StatBar label="MP" value={mp} className="stat-bar-mp" />
+          <StatBar label="HP" value={hp} />
+          <StatBar label="MP" value={mp} />
         </div>
       </div>
     </div>

--- a/src/components/molecules/profile/Profile.js
+++ b/src/components/molecules/profile/Profile.js
@@ -3,14 +3,18 @@ import React, { useState } from "react";
 import StatBar from "../../atoms/stat-bar/StatBar";
 import "./Profile.scss";
 
-// Random stat value between 75 and 100 (inclusive-ish), rounded to whole number
-function randomStat() {
-  return Math.floor(Math.random() * (100 - 75 + 1)) + 75;
+const MAX_HP = 100;
+const MAX_MP = 50;
+
+// Random stat value between 75% and 100% of max (inclusive-ish), rounded to whole number
+function randomStat(max) {
+  const min = Math.floor(max * 0.75);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
 function Profile({ profile, label }) {
   // Computed once per mount so the values don't jitter on re-render
-  const [{ hp, mp }] = useState(() => ({ hp: randomStat(), mp: randomStat() }));
+  const [{ hp, mp }] = useState(() => ({ hp: randomStat(MAX_HP), mp: randomStat(MAX_MP) }));
 
   return (
     <div className="profile-container">
@@ -20,8 +24,8 @@ function Profile({ profile, label }) {
         <div>LVL: Senior Software Engineer</div>
         <div>JOB: Editing Performance @ Canva</div>
         <div className="profile-stats">
-          <StatBar label="HP" value={hp} />
-          <StatBar label="MP" value={mp} />
+          <StatBar label="HP" value={hp} max={MAX_HP} />
+          <StatBar label="MP" value={mp} max={MAX_MP} />
         </div>
       </div>
     </div>

--- a/src/components/molecules/profile/Profile.js
+++ b/src/components/molecules/profile/Profile.js
@@ -1,7 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import "./Profile.scss";
 
+// Random stat value between 75 and 100 (inclusive-ish), rounded to whole number
+function randomStat() {
+  return Math.floor(Math.random() * (100 - 75 + 1)) + 75;
+}
+
+function StatBar({ label, value, className }) {
+  return (
+    <div className={`stat-bar ${className}`}>
+      <span className="stat-bar-label">{label}</span>
+      <div className="stat-bar-track">
+        <div className="stat-bar-fill" style={{ width: `${value}%` }} />
+      </div>
+      <span className="stat-bar-value">{value}%</span>
+    </div>
+  );
+}
+
 function Profile({ profile, label }) {
+  // Computed once per mount so the values don't jitter on re-render
+  const [hp] = useState(() => randomStat());
+  const [mp] = useState(() => randomStat());
+
   return (
     <div className="profile-container">
       <img className="profile-image" src={profile} alt="Chubby the chocobo" />
@@ -9,6 +30,10 @@ function Profile({ profile, label }) {
         <h4>{label}</h4>
         <div>LVL: Senior Software Engineer</div>
         <div>JOB: Editing Performance @ Canva</div>
+        <div className="profile-stats">
+          <StatBar label="HP" value={hp} className="stat-bar-hp" />
+          <StatBar label="MP" value={mp} className="stat-bar-mp" />
+        </div>
       </div>
     </div>
   );

--- a/src/components/molecules/profile/Profile.scss
+++ b/src/components/molecules/profile/Profile.scss
@@ -1,5 +1,12 @@
 @import "../../../styles/theme";
 
+// Local stat-bar colors, kept in step with the existing theme palette.
+// HP: a green in the spirit of $color-secondary-blue's saturation/value,
+// nudged toward the classic JRPG "healthy" tint.
+$color-stat-hp: #3fbf6f;
+// MP: reuse the theme's secondary blue tints directly.
+$color-stat-mp: $color-secondary-blue;
+
 .profile-container {
   display: flex;
   flex-direction: row;
@@ -24,5 +31,58 @@
     align-items: flex-start;
 
     margin: $spacing-4;
+
+    .profile-stats {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      margin-top: $spacing-2;
+      gap: $spacing-1;
+    }
+
+    .stat-bar {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      width: 100%;
+
+      font-size: $font-xs;
+
+      .stat-bar-label {
+        width: 1.5rem;
+        font-weight: $font-bold;
+        color: $color-primary-dark;
+      }
+
+      .stat-bar-track {
+        flex: 1;
+        height: $spacing-2;
+        margin: 0 $spacing-2;
+        background-color: $color-grey-1;
+        border: 1px solid $color-primary-dark;
+        border-radius: 2px;
+        overflow: hidden;
+      }
+
+      .stat-bar-fill {
+        height: 100%;
+        border-radius: 1px;
+        transition: width $a-short ease-in-out;
+      }
+
+      .stat-bar-value {
+        width: 2.25rem;
+        text-align: right;
+        color: $color-primary-grey;
+      }
+
+      &.stat-bar-hp .stat-bar-fill {
+        background-color: $color-stat-hp;
+      }
+
+      &.stat-bar-mp .stat-bar-fill {
+        background-color: $color-stat-mp;
+      }
+    }
   }
 }

--- a/src/components/molecules/profile/Profile.scss
+++ b/src/components/molecules/profile/Profile.scss
@@ -1,12 +1,5 @@
 @import "../../../styles/theme";
 
-// Local stat-bar colors, kept in step with the existing theme palette.
-// HP: a green in the spirit of $color-secondary-blue's saturation/value,
-// nudged toward the classic JRPG "healthy" tint.
-$color-stat-hp: #3fbf6f;
-// MP: reuse the theme's secondary blue tints directly.
-$color-stat-mp: $color-secondary-blue;
-
 .profile-container {
   display: flex;
   flex-direction: row;
@@ -38,51 +31,6 @@ $color-stat-mp: $color-secondary-blue;
       width: 100%;
       margin-top: $spacing-2;
       gap: $spacing-1;
-    }
-
-    .stat-bar {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      width: 100%;
-
-      font-size: $font-xs;
-
-      .stat-bar-label {
-        width: 1.5rem;
-        font-weight: $font-bold;
-        color: $color-primary-dark;
-      }
-
-      .stat-bar-track {
-        flex: 1;
-        height: $spacing-2;
-        margin: 0 $spacing-2;
-        background-color: $color-grey-1;
-        border: 1px solid $color-primary-dark;
-        border-radius: 2px;
-        overflow: hidden;
-      }
-
-      .stat-bar-fill {
-        height: 100%;
-        border-radius: 1px;
-        transition: width $a-short ease-in-out;
-      }
-
-      .stat-bar-value {
-        width: 2.25rem;
-        text-align: right;
-        color: $color-primary-grey;
-      }
-
-      &.stat-bar-hp .stat-bar-fill {
-        background-color: $color-stat-hp;
-      }
-
-      &.stat-bar-mp .stat-bar-fill {
-        background-color: $color-stat-mp;
-      }
     }
   }
 }

--- a/src/components/pages/resource/Resource.js
+++ b/src/components/pages/resource/Resource.js
@@ -3,7 +3,6 @@ import "./Resource.scss";
 import Page from "../../atoms/page/Page";
 import Icon from "../../atoms/icon/Icon";
 import linkedin from "../../../assets/linkedin.png";
-import document from "../../../assets/document.png";
 import github from "../../../assets/github.png";
 
 function Resource() {

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -34,6 +34,9 @@ $color-secondary-dark-2: #60666b;
 $color-secondary-dark-3: #8e9295;
 $color-secondary-dark-4: #b7bbbe;
 
+// Status colors
+$color-stat-hp: #3fbf6f;
+
 // Greys
 
 $color-grey-1: #eeeeee;


### PR DESCRIPTION
# Intent
Give the profile card a JRPG stat-window flourish.

# Solution
Randomized HP/MP bars (75–100%, rolled once per mount).

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/before-home-desktop.png) | ![after](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/after-profile-bars.png) |
