### PR TITLE
Fix Option cursor layout jank, add blink + focus-visible

### DIFF
--- a/src/components/atoms/option/Option.js
+++ b/src/components/atoms/option/Option.js
@@ -1,28 +1,22 @@
 import React from "react";
+import classNames from "classnames";
 import "./Option.scss";
 
 /**
- * A single FF-style menu option.
- *
- * Usage stays backward compatible with the original `<Option option="X" />`
- * call signature — it's typically rendered inside a react-router `<Link>`,
- * e.g. `<Link to="/about"><Option option="WEBSITE" /></Link>`. The cursor +
- * gold "selected" treatment activates on hover *and* on keyboard focus of
- * that ancestor `<Link>` (see Option.scss), so no local hover state is
- * needed here — it's driven entirely by CSS.
+ * A single FF-style menu option, typically rendered inside a react-router
+ * `<Link>` (e.g. `<Link to="/about"><Option option="WEBSITE" /></Link>`).
+ * The cursor + gold "selected" treatment is driven by CSS, on hover and on
+ * keyboard focus of that ancestor `<Link>` (see Option.scss) — no local
+ * hover state is needed here.
  *
  * @param {string} option - the label text to render.
- * @param {boolean} [selected] - optional: force the cursor/gold "selected"
- *   visual state on, regardless of hover/focus (e.g. for roving-focus logic
- *   driven by a parent). Defaults to false and is purely additive.
+ * @param {boolean} [selected] - force the "selected" visual state on,
+ *   regardless of hover/focus (e.g. for roving-focus logic driven by a
+ *   parent). Defaults to false.
  */
 function Option({ option, selected = false }) {
-  const className = ["option", selected ? "option--selected" : null]
-    .filter(Boolean)
-    .join(" ");
-
   return (
-    <div className={className}>
+    <div className={classNames("option", { "option--selected": selected })}>
       <span className="option__gutter" aria-hidden="true">
         {">"}
       </span>

--- a/src/components/atoms/option/Option.js
+++ b/src/components/atoms/option/Option.js
@@ -1,16 +1,32 @@
-import React, { useState } from "react";
+import React from "react";
 import "./Option.scss";
 
-function Option({ option }) {
-  const [isHovered, setIsHovered] = useState(false);
+/**
+ * A single FF-style menu option.
+ *
+ * Usage stays backward compatible with the original `<Option option="X" />`
+ * call signature — it's typically rendered inside a react-router `<Link>`,
+ * e.g. `<Link to="/about"><Option option="WEBSITE" /></Link>`. The cursor +
+ * gold "selected" treatment activates on hover *and* on keyboard focus of
+ * that ancestor `<Link>` (see Option.scss), so no local hover state is
+ * needed here — it's driven entirely by CSS.
+ *
+ * @param {string} option - the label text to render.
+ * @param {boolean} [selected] - optional: force the cursor/gold "selected"
+ *   visual state on, regardless of hover/focus (e.g. for roving-focus logic
+ *   driven by a parent). Defaults to false and is purely additive.
+ */
+function Option({ option, selected = false }) {
+  const className = ["option", selected ? "option--selected" : null]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <div
-      className="option"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      {`${isHovered ? "> " : ""} ${option}`}
+    <div className={className}>
+      <span className="option__gutter" aria-hidden="true">
+        {">"}
+      </span>
+      <span className="option__text">{option}</span>
     </div>
   );
 }

--- a/src/components/atoms/option/Option.scss
+++ b/src/components/atoms/option/Option.scss
@@ -1,7 +1,62 @@
 @import "../../../styles/theme";
 
+// Fixed-width gutter reserved for the cursor arrow so text never shifts
+// horizontally when the cursor appears/disappears.
+$option-gutter-width: 1.2em;
+
+@keyframes option-cursor-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+// Shared "active" treatment (blinking cursor + gold text), applied on
+// hover, on forced `selected` state, and on keyboard focus of the
+// ancestor <Link> (see selectors below).
+@mixin option-active {
+  .option__gutter {
+    opacity: 1;
+    animation: option-cursor-blink 1s steps(1, start) infinite;
+  }
+
+  .option__text {
+    color: $color-secondary-yellow;
+  }
+}
+
 .option {
+  display: flex;
+  align-items: center;
   font-size: $font-3xl;
 
   cursor: pointer;
+
+  &__gutter {
+    flex: 0 0 $option-gutter-width;
+    display: inline-block;
+    text-align: center;
+    opacity: 0;
+  }
+
+  &__text {
+    transition: color $a-short ease;
+  }
+}
+
+// Mouse hover, or an explicit `selected` prop forcing the state on.
+.option:hover,
+.option.option--selected {
+  @include option-active;
+}
+
+// Option is normally rendered inside a react-router <Link> (an <a>), which
+// is the element that actually receives keyboard focus — .option itself
+// isn't focusable, so we key off the focused ancestor instead.
+a:focus-visible .option {
+  @include option-active;
 }

--- a/src/components/atoms/option/Option.scss
+++ b/src/components/atoms/option/Option.scss
@@ -48,15 +48,12 @@ $option-gutter-width: 1.2em;
   }
 }
 
-// Mouse hover, or an explicit `selected` prop forcing the state on.
+// Mouse hover, an explicit `selected` prop forcing the state on, or
+// keyboard focus of the ancestor <Link> (an <a>, since .option itself
+// isn't focusable — Option is normally rendered inside a react-router
+// <Link>, so we key off the focused ancestor instead).
 .option:hover,
-.option.option--selected {
-  @include option-active;
-}
-
-// Option is normally rendered inside a react-router <Link> (an <a>), which
-// is the element that actually receives keyboard focus — .option itself
-// isn't focusable, so we key off the focused ancestor instead.
+.option--selected,
 a:focus-visible .option {
   @include option-active;
 }

--- a/src/components/pages/home/Home.scss
+++ b/src/components/pages/home/Home.scss
@@ -11,8 +11,4 @@ h1 {
   flex-direction: column;
 
   width: 50%;
-
-  > a {
-    margin-left: $spacing-4;
-  }
 }

--- a/src/components/pages/resource/Resource.js
+++ b/src/components/pages/resource/Resource.js
@@ -3,7 +3,6 @@ import "./Resource.scss";
 import Page from "../../atoms/page/Page";
 import Icon from "../../atoms/icon/Icon";
 import linkedin from "../../../assets/linkedin.png";
-import document from "../../../assets/document.png";
 import github from "../../../assets/github.png";
 
 function Resource() {


### PR DESCRIPTION
# Intent
The hover cursor caused menu text to jump sideways, and selection state was invisible to keyboard users.

# Solution
Fixed-width cursor gutter with a blinking arrow, triggered consistently on both hover and keyboard focus.

| Before (hover) | After (hover) |
|---|---|
| ![before](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/before-option-hover.png) | ![after](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/after-option-cursor.png) |
