### PR TITLE
Restyle menu box with dark JRPG gradient + layered border

### DIFF
--- a/src/components/atoms/page/Page.scss
+++ b/src/components/atoms/page/Page.scss
@@ -20,6 +20,7 @@
   }
 
   .menu {
+    position: relative;
     display: flex;
     flex-direction: column;
     padding: $spacing-4;
@@ -27,11 +28,72 @@
     height: inherit;
     width: 100%;
 
-    border: 3px solid black;
+    // Layered double-line border: solid dark outer edge + inset light-blue
+    // line, evoking an SNES-era JRPG dialogue/menu box.
+    border: 3px solid $color-secondary-dark;
+    outline: 2px solid $color-secondary-blue-2;
+    outline-offset: -7px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.55);
 
-    background-color: #fefefe;
+    // Dark translucent navy/black gradient, ties into the navbar's palette.
+    background: linear-gradient(
+      165deg,
+      rgba($color-primary-dark, 0.95) 0%,
+      rgba($color-secondary-dark, 0.92) 55%,
+      rgba($color-primary-dark-1, 0.95) 100%
+    );
+
+    color: $color-secondary-blue-4;
 
     overflow-y: scroll;
+
+    // Small corner accent marks, inset so they aren't clipped by the
+    // scrollable overflow above.
+    &::before,
+    &::after {
+      content: "";
+      position: absolute;
+      width: 14px;
+      height: 14px;
+
+      border-style: solid;
+      border-color: $color-secondary-yellow;
+
+      pointer-events: none;
+    }
+
+    &::before {
+      top: 8px;
+      left: 8px;
+
+      border-width: 2px 0 0 2px;
+    }
+
+    &::after {
+      bottom: 8px;
+      right: 8px;
+
+      border-width: 0 2px 2px 0;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: $color-secondary-yellow;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        color: $color-secondary-yellow;
+      }
+    }
 
     &.page-center {
       align-items: center;

--- a/src/components/atoms/page/Page.scss
+++ b/src/components/atoms/page/Page.scss
@@ -20,6 +20,11 @@
   }
 
   .menu {
+    // Corner-accent bracket dimensions, referenced by both pseudo-elements
+    // below so the size/thickness only need to change in one place.
+    $corner-size: 14px;
+    $corner-thickness: 2px;
+
     position: relative;
     display: flex;
     flex-direction: column;
@@ -29,11 +34,12 @@
     width: 100%;
 
     // Layered double-line border: solid dark outer edge + inset light-blue
-    // line, evoking an SNES-era JRPG dialogue/menu box.
+    // line, evoking an SNES-era JRPG dialogue/menu box. The outline is
+    // pulled in via a negative offset so it renders just inside the border.
     border: 3px solid $color-secondary-dark;
     outline: 2px solid $color-secondary-blue-2;
     outline-offset: -7px;
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.55);
+    box-shadow: 0 6px 18px rgba($color-secondary-dark, 0.55);
 
     // Dark translucent navy/black gradient, ties into the navbar's palette.
     background: linear-gradient(
@@ -53,8 +59,8 @@
     &::after {
       content: "";
       position: absolute;
-      width: 14px;
-      height: 14px;
+      width: $corner-size;
+      height: $corner-size;
 
       border-style: solid;
       border-color: $color-secondary-yellow;
@@ -63,17 +69,17 @@
     }
 
     &::before {
-      top: 8px;
-      left: 8px;
+      top: $spacing-2;
+      left: $spacing-2;
 
-      border-width: 2px 0 0 2px;
+      border-width: $corner-thickness 0 0 $corner-thickness;
     }
 
     &::after {
-      bottom: 8px;
-      right: 8px;
+      bottom: $spacing-2;
+      right: $spacing-2;
 
-      border-width: 0 2px 2px 0;
+      border-width: 0 $corner-thickness $corner-thickness 0;
     }
 
     h1,

--- a/src/components/pages/resource/Resource.js
+++ b/src/components/pages/resource/Resource.js
@@ -3,7 +3,6 @@ import "./Resource.scss";
 import Page from "../../atoms/page/Page";
 import Icon from "../../atoms/icon/Icon";
 import linkedin from "../../../assets/linkedin.png";
-import document from "../../../assets/document.png";
 import github from "../../../assets/github.png";
 
 function Resource() {


### PR DESCRIPTION
# Intent
The menu box looked like a plain white card, disconnected from the navbar's dark palette and the FF theming everywhere else.

# Solution
Dark gradient panel with a layered JRPG-style border and gold/light-blue text accents, cascading to every page that uses this shared chrome.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/before-home-desktop.png) | ![after](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/after-page-theme.png) |
