### PR TITLE
Restructure Home into two-pane PARTY/Menu layout with keyboard nav

### DIFF
--- a/src/components/atoms/page/Page.js
+++ b/src/components/atoms/page/Page.js
@@ -1,17 +1,44 @@
-import React from "react";
+import React, { useEffect } from "react";
 import classNames from "classnames";
 import "./Page.scss";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
+import { playCancelSound } from "../sfx/sfx";
 
 function Page(props) {
+  const history = useHistory();
+
+  useEffect(() => {
+    if (!props.back) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      const { tagName, isContentEditable } = event.target;
+      if (
+        event.key !== "Backspace" ||
+        tagName === "INPUT" ||
+        tagName === "TEXTAREA" ||
+        isContentEditable
+      ) {
+        return;
+      }
+
+      playCancelSound();
+      history.push("/");
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [props.back, history]);
+
   return (
     <div className="page">
-      {props.back && (
-        <div className="back">
-          <Link to="/">{"< Back"}</Link>
-        </div>
-      )}
       <div className={classNames("menu", { "page-center": props.center })}>
+        {props.back && (
+          <div className="back">
+            <Link to="/">{"< Back"}</Link>
+          </div>
+        )}
         {props.children}
       </div>
     </div>

--- a/src/components/atoms/page/Page.scss
+++ b/src/components/atoms/page/Page.scss
@@ -11,13 +11,9 @@
 
   height: inherit;
   width: 70%;
-  max-width: $monitor-sm;
+  max-width: $monitor;
   min-width: $mobile-sm;
   max-height: 640px;
-
-  .back {
-    font-size: $font-2xl;
-  }
 
   .menu {
     display: flex;
@@ -33,6 +29,11 @@
 
     overflow-y: scroll;
 
+    .back {
+      font-size: $font-2xl;
+      margin-bottom: $spacing-2;
+    }
+
     &.page-center {
       align-items: center;
       justify-content: center;
@@ -41,6 +42,7 @@
 
   @media screen and (max-width: $mobile) {
     width: 100%;
+    max-height: none;
     overflow-x: scroll;
     overflow-y: scroll;
   }

--- a/src/components/pages/home/Home.js
+++ b/src/components/pages/home/Home.js
@@ -26,6 +26,10 @@ function Home() {
   const menuRefs = useRef([]);
   const partyRefs = useRef([]);
 
+  const setRef = (refs, index) => (el) => {
+    refs.current[index] = el;
+  };
+
   const focusMenuItem = (index) => {
     const total = menuRefs.current.length;
     menuRefs.current[(index + total) % total]?.focus();
@@ -72,9 +76,7 @@ function Home() {
               <Link
                 key={member.name}
                 to={member.link}
-                ref={(el) => {
-                  partyRefs.current[index] = el;
-                }}
+                ref={setRef(partyRefs, index)}
                 onKeyDown={handlePartyKeyDown}
               >
                 <Profile profile={member.profile} label={member.name} />
@@ -89,27 +91,26 @@ function Home() {
           <div className="menu-options">
             <a
               href="#party-pane"
-              ref={(el) => {
-                menuRefs.current[0] = el;
-              }}
+              ref={setRef(menuRefs, 0)}
               onClick={handleSelectParty}
               onKeyDown={(event) => handleMenuKeyDown(event, 0)}
             >
               <Option option="PARTY" />
             </a>
-            {menuItems.map((item, index) => (
-              <Link
-                key={item.label}
-                to={item.to}
-                ref={(el) => {
-                  menuRefs.current[index + 1] = el;
-                }}
-                onClick={playConfirmSound}
-                onKeyDown={(event) => handleMenuKeyDown(event, index + 1)}
-              >
-                <Option option={item.label} />
-              </Link>
-            ))}
+            {menuItems.map((item, index) => {
+              const menuIndex = index + 1;
+              return (
+                <Link
+                  key={item.label}
+                  to={item.to}
+                  ref={setRef(menuRefs, menuIndex)}
+                  onClick={playConfirmSound}
+                  onKeyDown={(event) => handleMenuKeyDown(event, menuIndex)}
+                >
+                  <Option option={item.label} />
+                </Link>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/components/pages/home/Home.js
+++ b/src/components/pages/home/Home.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import Profile from "../../molecules/profile/Profile";
 import Option from "../../atoms/option/Option";
@@ -11,8 +11,8 @@ import {
 } from "../../atoms/sfx/sfx";
 import "./Home.scss";
 
-// Right-pane command menu. PARTY is handled separately (index 0) since it
-// switches focus into the left pane rather than navigating to a route.
+// Left-pane command menu. PARTY is handled separately (index 0) since it
+// switches focus into the right pane rather than navigating to a route.
 const menuItems = [
   { label: "WEBSITE", to: "/about/website" },
   { label: "RESOURCES", to: "/resources" },
@@ -35,6 +35,12 @@ function Home() {
     menuRefs.current[(index + total) % total]?.focus();
   };
 
+  // Autofocus PARTY on mount so arrow-key nav works immediately, without
+  // requiring a Tab press first.
+  useEffect(() => {
+    menuRefs.current[0]?.focus();
+  }, []);
+
   const handleMenuKeyDown = (event, index) => {
     if (event.key === "ArrowDown") {
       event.preventDefault();
@@ -48,7 +54,7 @@ function Home() {
   };
 
   // Selecting PARTY (Enter or click) doesn't navigate anywhere — it moves
-  // focus into the left pane, onto the first party member.
+  // focus into the right pane, onto the first party member.
   const handleSelectParty = (event) => {
     event.preventDefault();
     playConfirmSound();
@@ -67,23 +73,6 @@ function Home() {
   return (
     <Page>
       <div className="home-panes">
-        <div className="party-pane" id="party-pane">
-          <h1>
-            <u>Party</u>
-          </h1>
-          <div className="party-list">
-            {party.map((member, index) => (
-              <Link
-                key={member.name}
-                to={member.link}
-                ref={setRef(partyRefs, index)}
-                onKeyDown={handlePartyKeyDown}
-              >
-                <Profile profile={member.profile} label={member.name} />
-              </Link>
-            ))}
-          </div>
-        </div>
         <div className="menu-pane">
           <h1>
             <u>Menu</u>
@@ -111,6 +100,23 @@ function Home() {
                 </Link>
               );
             })}
+          </div>
+        </div>
+        <div className="party-pane" id="party-pane">
+          <h1>
+            <u>Party</u>
+          </h1>
+          <div className="party-list">
+            {party.map((member, index) => (
+              <Link
+                key={member.name}
+                to={member.link}
+                ref={setRef(partyRefs, index)}
+                onKeyDown={handlePartyKeyDown}
+              >
+                <Profile profile={member.profile} label={member.name} />
+              </Link>
+            ))}
           </div>
         </div>
       </div>

--- a/src/components/pages/home/Home.js
+++ b/src/components/pages/home/Home.js
@@ -1,40 +1,117 @@
-import React from "react";
-import profile from "../../../assets/profile.jpg";
+import React, { useRef } from "react";
+import { Link } from "react-router-dom";
 import Profile from "../../molecules/profile/Profile";
 import Option from "../../atoms/option/Option";
 import Page from "../../atoms/page/Page";
-import { Link } from "react-router-dom";
+import party from "./party";
+import {
+  playMoveSound,
+  playConfirmSound,
+  playCancelSound,
+} from "../../atoms/sfx/sfx";
 import "./Home.scss";
 
+// Right-pane command menu. PARTY is handled separately (index 0) since it
+// switches focus into the left pane rather than navigating to a route.
+const menuItems = [
+  { label: "WEBSITE", to: "/about/website" },
+  { label: "RESOURCES", to: "/resources" },
+  { label: "PROJECTS", to: "/projects" },
+  { label: "CONTACT", to: "/contact" },
+];
+
 function Home() {
+  // Roving DOM focus: refs to the real anchor elements, in visual/nav
+  // order. index 0 of menuRefs is always the PARTY entry.
+  const menuRefs = useRef([]);
+  const partyRefs = useRef([]);
+
+  const focusMenuItem = (index) => {
+    const total = menuRefs.current.length;
+    menuRefs.current[(index + total) % total]?.focus();
+  };
+
+  const handleMenuKeyDown = (event, index) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      playMoveSound();
+      focusMenuItem(index + 1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      playMoveSound();
+      focusMenuItem(index - 1);
+    }
+  };
+
+  // Selecting PARTY (Enter or click) doesn't navigate anywhere — it moves
+  // focus into the left pane, onto the first party member.
+  const handleSelectParty = (event) => {
+    event.preventDefault();
+    playConfirmSound();
+    partyRefs.current[0]?.focus();
+  };
+
+  // Backspace from within the party pane returns focus to the PARTY entry.
+  const handlePartyKeyDown = (event) => {
+    if (event.key === "Backspace") {
+      event.preventDefault();
+      playCancelSound();
+      menuRefs.current[0]?.focus();
+    }
+  };
+
   return (
     <Page>
-      <h1>
-        <u>Characters</u>
-      </h1>
-      <div className="menu-container">
-        <div className="profile">
-          <Link to="/about">
-            <Profile profile={profile} label="Kenneth Lu" />
-          </Link>
+      <div className="home-panes">
+        <div className="party-pane" id="party-pane">
+          <h1>
+            <u>Party</u>
+          </h1>
+          <div className="party-list">
+            {party.map((member, index) => (
+              <Link
+                key={member.name}
+                to={member.link}
+                ref={(el) => {
+                  partyRefs.current[index] = el;
+                }}
+                onKeyDown={handlePartyKeyDown}
+              >
+                <Profile profile={member.profile} label={member.name} />
+              </Link>
+            ))}
+          </div>
         </div>
-      </div>
-      <h1>
-        <u>Menu</u>
-      </h1>
-      <div className="menu-options">
-        <Link to="/about/website">
-          <Option option="WEBSITE" />
-        </Link>
-        <Link to="/resources">
-          <Option option="RESOURCES" />
-        </Link>
-        <Link to="/projects">
-          <Option option="PROJECTS" />
-        </Link>
-        <Link to="/contact">
-          <Option option="CONTACT" />
-        </Link>
+        <div className="menu-pane">
+          <h1>
+            <u>Menu</u>
+          </h1>
+          <div className="menu-options">
+            <a
+              href="#party-pane"
+              ref={(el) => {
+                menuRefs.current[0] = el;
+              }}
+              onClick={handleSelectParty}
+              onKeyDown={(event) => handleMenuKeyDown(event, 0)}
+            >
+              <Option option="PARTY" />
+            </a>
+            {menuItems.map((item, index) => (
+              <Link
+                key={item.label}
+                to={item.to}
+                ref={(el) => {
+                  menuRefs.current[index + 1] = el;
+                }}
+                onClick={playConfirmSound}
+                onKeyDown={(event) => handleMenuKeyDown(event, index + 1)}
+              >
+                <Option option={item.label} />
+              </Link>
+            ))}
+          </div>
+        </div>
       </div>
     </Page>
   );

--- a/src/components/pages/home/Home.scss
+++ b/src/components/pages/home/Home.scss
@@ -8,7 +8,6 @@ h1 {
 
 .home-panes {
   display: flex;
-  flex-direction: row;
   gap: $spacing-4;
 
   width: 100%;

--- a/src/components/pages/home/Home.scss
+++ b/src/components/pages/home/Home.scss
@@ -6,13 +6,44 @@ h1 {
   width: 100%;
 }
 
-.menu-options {
+.home-panes {
+  display: flex;
+  flex-direction: row;
+  gap: $spacing-4;
+
+  width: 100%;
+}
+
+.party-pane,
+.menu-pane {
   display: flex;
   flex-direction: column;
 
   width: 50%;
+}
+
+.party-list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.menu-options {
+  display: flex;
+  flex-direction: column;
 
   > a {
     margin-left: $spacing-4;
+  }
+}
+
+@media screen and (max-width: $mobile) {
+  .home-panes {
+    flex-direction: column;
+  }
+
+  .party-pane,
+  .menu-pane {
+    width: 100%;
   }
 }

--- a/src/components/pages/home/party.js
+++ b/src/components/pages/home/party.js
@@ -1,0 +1,15 @@
+import profile from "../../../assets/profile.jpg";
+
+// Array-driven party (character) list for the Home page's left pane.
+// Currently just one member — additional party members are just future
+// entries in this array, following the same pattern as Project.js's
+// `projects` array.
+const party = [
+  {
+    name: "Kenneth Lu",
+    profile,
+    link: "/about",
+  },
+];
+
+export default party;

--- a/src/index.scss
+++ b/src/index.scss
@@ -26,7 +26,7 @@ a:hover {
   justify-content: center;
   margin: auto;
 
-  max-width: $monitor-sm;
+  max-width: $monitor;
   min-width: $mobile-sm;
   height: calc(100vh - #{$spacing-32});
 

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -78,7 +78,7 @@ $spacing-64: 16rem;
 // Screen sizes
 $mobile-sm: 320px;
 $mobile: 480px;
-$monitor-sm: 760px;
+$monitor: 1280px;
 
 // Animation time
 $a-short: 0.3s;


### PR DESCRIPTION
# Intent
Home was a flat single-column list; it should read as an actual FF-style menu with a party pane and keyboard-first navigation.

# Solution
Two-pane PARTY/Menu layout, array-driven party data, roving keyboard focus (arrows/Enter/Backspace) with sound feedback, stacking to one column on mobile.

| | Before | After |
|---|---|---|
| Desktop | ![before desktop](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/before-home-desktop.png) | ![after desktop](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/after-home-desktop.png) |
| Mobile | ![before mobile](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/before-home-mobile.png) | ![after mobile](https://raw.githubusercontent.com/kenzclu/ff-homepage/pr-screenshots/screenshots/after-home-mobile.png) |

Depends on #6 (SFX module) — merge that first. Screenshots are from this branch alone, so the box/cursor styling still looks like the old theme; #9 and #8 fill that in separately.
