### PR TITLE
Fix mobile background gap and forced horizontal scrollbar

### DIFF
--- a/src/components/atoms/page/Page.scss
+++ b/src/components/atoms/page/Page.scss
@@ -43,7 +43,7 @@
   @media screen and (max-width: $mobile) {
     width: 100%;
     max-height: none;
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: scroll;
   }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -4,9 +4,18 @@
 
 body {
   min-width: 320px;
+  min-height: 100vh;
+  min-height: 100dvh;
   font-family: "Open Sans", sans-serif;
 
   background-image: url(./assets/background.jpg);
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-attachment: fixed;
+
+  @media screen and (max-width: $mobile) {
+    background-attachment: scroll;
+  }
 }
 
 a {
@@ -29,8 +38,4 @@ a:hover {
   max-width: $monitor;
   min-width: $mobile-sm;
   height: calc(100vh - #{$spacing-32});
-
-  background-attachment: fixed;
-  background-repeat: no-repeat;
-  background-size: cover;
 }


### PR DESCRIPTION
## Intent
On mobile, the page background didn't reach the bottom of the viewport, leaving a white gap. `.page` also forced a horizontal scrollbar on every mobile screen even when nothing overflowed horizontally.

## Solution
- Give `body` a `min-height` (100vh/100dvh) so the background always covers the full viewport, independent of content height, and move the actual background rendering (image, size, repeat, attachment) onto `body` where the image lives.
- Disable `background-attachment: fixed` on mobile to avoid scroll jank on iOS/Android.
- Change the mobile `overflow-x` from `scroll` to `auto` so a scrollbar only appears when content actually overflows.